### PR TITLE
Changes to support ESPHome 1.15

### DIFF
--- a/components/st7735/display.py
+++ b/components/st7735/display.py
@@ -19,7 +19,7 @@ CONFIG_SCHEMA = display.FULL_DISPLAY_SCHEMA.extend({
     cv.Required(CONF_DC_PIN): pins.gpio_output_pin_schema,
     cv.Required(CONF_CS_PIN): pins.gpio_output_pin_schema,
     cv.Optional(CONF_BRIGHTNESS, default=1.0): cv.percentage,
-}).extend(cv.polling_component_schema('1s')).extend(spi.SPI_DEVICE_SCHEMA)
+}).extend(cv.polling_component_schema('1s')).extend(spi.spi_device_schema())
 
 
 def to_code(config):

--- a/components/st7735/st7735.cpp
+++ b/components/st7735/st7735.cpp
@@ -162,10 +162,7 @@ void ST7735::setup() {
   this->displayInit(Rcmd3);
   this->writecommand(ST7735_INVON);
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  //this->disable();
   delay(120);
-  //this->enable();
 
   this->writecommand(ST7735_DISPON);    //Display on
   delay(120);
@@ -270,18 +267,15 @@ size_t ST7735::get_buffer_length_() {
   return size_t(this->get_width_internal()) * size_t(this->get_height_internal()) * 2;
 }
 
-void HOT ST7735::draw_absolute_pixel_internal(int x, int y, int color) {
+
+void HOT ST7735::draw_absolute_pixel_internal(int x, int y, Color color) {
 	if (x >= this->get_width_internal() || x < 0 || y >= this->get_height_internal() || y < 0)
 		return;
 
-  if (color == display::COLOR_ON) {
-    color = ST7735_WHITE;
-  } else if (color == display::COLOR_OFF) {
-    color = ST7735_BLACK;
-  }
-	uint16_t pos = (x + y * this->get_width_internal())*2;
-	this->buffer_[pos++] = (color>>8) & 0xff;
-	this->buffer_[pos] = color & 0xff;
+  auto color565 = color.to_rgb_565();
+  uint16_t pos = (x + y * this->get_width_internal()) * 2;
+  this->buffer_[pos++] = (color565 >> 8) & 0xff;
+  this->buffer_[pos] = color565 & 0xff;
 }
 
 void ST7735::displayInit(const uint8_t *addr) {

--- a/components/st7735/st7735.h
+++ b/components/st7735/st7735.h
@@ -136,8 +136,8 @@ class ST7735 : public PollingComponent, public display::DisplayBuffer,
   
   void spi_master_write_addr(uint16_t addr1, uint16_t addr2);
   void spi_master_write_color(uint16_t color, uint16_t size);
-  
-  void draw_absolute_pixel_internal(int x, int y, int color) override;
+
+  void draw_absolute_pixel_internal(int x, int y, Color color) override;
 
   int get_height_internal() override;
   int get_width_internal() override;

--- a/components/st7735/st7735.h
+++ b/components/st7735/st7735.h
@@ -80,16 +80,30 @@
 #define ST7735_NVMSET		0xFC      // NVM setting
 #define ST7735_PROMACT		0xFE      // Program action
 
+namespace esphome {
+namespace st7735 {
+
+template <int N>
+struct Color565 {
+  operator Color () const
+  {
+    return Color((((N)&0xF800) >> 8), (((N)&0x07E0) >> 3), (((N)&0x001F) << 3));
+  }
+};
+
+}  // namespace st7735
+}  // namespace esphome
+
 // Some ready-made 16-bit ('565') color settings:
-#define ST77XX_BLACK      0x0000
-#define ST77XX_WHITE      0xFFFF
-#define ST77XX_RED        0xF800
-#define ST77XX_GREEN      0x07E0
-#define ST77XX_BLUE       0x001F
-#define ST77XX_CYAN       0x07FF
-#define ST77XX_MAGENTA    0xF81F
-#define ST77XX_YELLOW     0xFFE0
-#define ST77XX_ORANGE     0xFC00
+#define ST77XX_BLACK       esphome::st7735::Color565<0x0000>{}    /*   0,   0,   0 */
+#define ST77XX_WHITE       esphome::st7735::Color565<0xFFFF>{}    /* 255, 255, 255 */
+#define ST77XX_RED         esphome::st7735::Color565<0xF800>{}    /* 255,   0,   0 */
+#define ST77XX_GREEN       esphome::st7735::Color565<0x07E0>{}    /*   0, 255,   0 */
+#define ST77XX_BLUE        esphome::st7735::Color565<0x001F>{}    /*   0,   0, 255 */
+#define ST77XX_CYAN        esphome::st7735::Color565<0x07FF>{}    /*   0, 255, 255 */
+#define ST77XX_MAGENTA     esphome::st7735::Color565<0xF81F>{}    /* 255,   0, 255 */
+#define ST77XX_YELLOW      esphome::st7735::Color565<0xFFE0>{}    /* 255, 255,   0 */
+#define ST77XX_ORANGE      esphome::st7735::Color565<0xFDA0>{}    /* 255, 180,   0 */
 
 // Some ready-made 16-bit ('565') color settings:
 #define ST7735_BLACK      ST77XX_BLACK


### PR DESCRIPTION
Hiya, So it looks like there were some breaking changes upstream for the display.  One was from PR https://github.com/esphome/esphome/pull/988 which "changed SPI_DEVICE_SCHEMA to a function, like i2c".  The second is with `draw_absolute_pixel_internal`.  It seems that the PR https://github.com/esphome/esphome/pull/1100 changed the internal color format from RGB565 to RGB888.  I updated that method, but that broke the `ST77XX_*` color defines.  I kinda hacked around it to preserve behavior, but I am wondering if it makes sense, since they were only included because mere mortals cannot do RGB565 conversions in their heads ;)

Let me know if you need any changes on this.  I am loving my M5Stick-C!!