### PR TITLE
Fixes compilation with esphome > 2022.2.6.

### DIFF
--- a/components/axp192/sensor.py
+++ b/components/axp192/sensor.py
@@ -13,8 +13,11 @@ AXP192Component = axp192_ns.class_('AXP192Component', cg.PollingComponent, i2c.I
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(AXP192Component),
     cv.Optional(CONF_BATTERY_LEVEL):
-        sensor.sensor_schema(UNIT_PERCENT, ICON_BATTERY, 1).extend({
-        }),
+        sensor.sensor_schema(
+            unit_of_measurement=UNIT_PERCENT,
+            accuracy_decimals=1,
+            icon=ICON_BATTERY,
+        ),
     cv.Optional(CONF_BRIGHTNESS, default=1.0): cv.percentage,
 }).extend(cv.polling_component_schema('60s')).extend(i2c.i2c_device_schema(0x77))
 


### PR DESCRIPTION
esphome versions after 2022.2.6 fail to compile axp192 with the
following error:

  File "/home/test/esphome/custom_components/axp192/sensor.py", line 16, in <module>
    sensor.sensor_schema(UNIT_PERCENT, ICON_BATTERY, 1).extend({
  TypeError: sensor_schema() takes from 0 to 1 positional arguments but 3 were given